### PR TITLE
Add Debian sub versions to choose from

### DIFF
--- a/recipes/_package_debian.rb
+++ b/recipes/_package_debian.rb
@@ -2,6 +2,10 @@ include_recipe 'apt'
 
 case node['platform_version'].to_f
   when 7
+  when 7.1
+  when 7.2
+  when 7.3
+  when 7.4
     release = 'wheezy'
 
   when 12.04


### PR DESCRIPTION
Debian 7 has some updates that make it impossible to use this package to install it.

By adding these possibilities it is now possible to install HHVM on debian 7.1, 7.2, 7.3 and 7.4
