### PR TITLE
Add option to specify release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | `node['hhvm']['installation_type']`               | package                                | Installation method ([`package`](#hhvmpackage) or [`source`](#hhvmsource))  |
 | **Package installation**                          |                                        |                                                                             |
 | `node['hhvm']['package']['type']`                 | default                                | Which HHVM package to install (one of dbg, nightly, nightly-dbg or default) |
+| `node['hhvm']['package']['debian_release']`       | nil                                    | If given, use that for the release when constructing URLs for the APT repository |
 | `node['hhvm']['setup_centos_hhvm_repo']`          | true                                   | If true, hop5.in will be installed on Centos hosts                          |
 | `node['hhvm']['setup_centos_epel_repo']`          | true                                   | If true, EPEL will be installed on Centos hosts                             |
 | **Source installation**                           |                                        |                                                                             |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,7 @@ default['hhvm']['installation_type'] = 'package'
 
 # Package installation
 default['hhvm']['package']['type'] = :default
+default['hhvm']['package']['debian_release'] = nil
 
 # If true, this cookbook will deploy a new repository (hop5.in) to install the 'hhvm' package.
 # Set to false if you already have 'hhvm' and all dependencies available on your own repository.

--- a/recipes/_package_debian.rb
+++ b/recipes/_package_debian.rb
@@ -1,6 +1,6 @@
 include_recipe 'apt'
 
-release = case node['platform_version'].to_f
+release = node['hhvm']['package']['debian_release'] || case node['platform_version'].to_f
 when 7...8
     'wheezy'
 

--- a/spec/unit/package_spec.rb
+++ b/spec/unit/package_spec.rb
@@ -24,7 +24,7 @@ describe 'hhvm::package' do
         end
     end
 
-    describe 'Ubnuntu' do
+    describe 'Ubuntu' do
         %w(12.04 13.10 14.04).each do |version|
             describe version do
               let(:chef_run) {
@@ -81,6 +81,36 @@ describe 'hhvm::package' do
                     expect(chef_run).to create_remote_file_if_missing('/tmp/epel.rpm')
                     expect(chef_run).to install_package('epel').with(source: '/tmp/epel.rpm')
                 end
+            end
+        end
+    end
+
+    describe 'Ubuntu with release override' do
+        %w(12.04 13.10 14.04).each do |version|
+            describe version do
+              let(:chef_run) {
+                  c = ChefSpec::SoloRunner.new(
+                      platform: 'ubuntu',
+                      version: version
+                  ) do |node|
+                    node.set['hhvm']['package']['debian_release'] = 'trusty-lts-3.3'
+                  end
+                  c.converge(described_recipe)
+              }
+
+              it 'Includes Debian recipe' do
+                  expect(chef_run).to include_recipe('hhvm::_package_debian')
+              end
+
+              if version == '12.04'
+                it 'Adds boost repository' do
+                  expect(chef_run).to add_apt_repository('mapnik-boost')
+                end
+              end
+
+              it 'Adds HHVM repository' do
+                expect(chef_run).to add_apt_repository('hhvm').with(distribution: 'trusty-lts-3.3')
+              end
             end
         end
     end


### PR DESCRIPTION
This allows one to specify the distribution's release, overriding the cookbook's guess mechanism. Fixes #21.
